### PR TITLE
Match solicitor names to emails

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,8 @@ NUMBER_OF_SOLICITORS = NUMBER_OF_FIRMS * SOLICITORS_PER_FIRM
 
 srand(100)
 
-solicitor_emails = Array.new(NUMBER_OF_SOLICITORS) { Faker::Internet.safe_email }.to_enum
+solicitor_names =  Array.new(NUMBER_OF_SOLICITORS) { Faker::Name.name }.to_enum
+solicitor_emails = solicitor_names.map { |name| Faker::Internet.safe_email name }.to_enum
 
 1.upto(NUMBER_OF_FIRMS) do
   #Seed with 10 firms
@@ -31,7 +32,7 @@ solicitor_emails = Array.new(NUMBER_OF_SOLICITORS) { Faker::Internet.safe_email 
 
   firm_id = firm.id
   1.upto(SOLICITORS_PER_FIRM) do
-    solicitor_name = Faker::Name.name
+    solicitor_name = solicitor_names.next
     solicitor_address = Faker::Address.street_address + ' ' + Faker::Address.country
     solicitor_postcode = ('A'..'Z').to_a.sample + ('A'..'Z').to_a.sample + ('1'..'9').to_a.sample + ' ' + ('1'..'9').to_a.sample + ('A'..'Z').to_a.sample + ('A'..'Z').to_a.sample
     solicitor_tel = ['0207 284 1111','0207 284 2222','0207 284 3333','0207 284 4444','0207 284 5555','0207 284 6666'].sample


### PR DESCRIPTION
Previously the solicitor emails contained names
that were different to the solicitors themselves.
eg. John Smith might have email:
`barry.jones@example.com`
